### PR TITLE
docs: Phase 1 完了に伴う進捗管理更新

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,6 +31,14 @@ Use these skills for detailed workflows:
 @docs/07_setup-guide.md
 @docs/08_deploy-guide.md
 
+# Task Completion Rules
+
+タスク完了時のルール:
+
+1. **Plans.md 更新必須**: タスクが完了したら、必ず `Plans.md` のチェックボックスを `[x]` に更新し、PR番号を記載する
+2. **進捗サマリー更新**: フェーズ完了時は進捗サマリーの数値も更新する
+3. **成果物リスト同期**: 実装完了した成果物は `docs/02_deliverables.md` の状態も更新する
+
 # Documentation Rules
 
 ドキュメント作成時のルール:

--- a/Plans.md
+++ b/Plans.md
@@ -2,7 +2,7 @@
 
 ## 現在のフェーズ
 
-**Phase 1: バックエンド基盤** - モデル・マイグレーション
+**Phase 2: バックエンドAPI** - コントローラー・サービス実装
 
 ---
 
@@ -18,65 +18,33 @@
 
 ---
 
-## Phase 1: バックエンド基盤（モデル・マイグレーション）
+## Phase 1: バックエンド基盤（モデル・マイグレーション） ✅
 
 ### 1.1 パーツテーブル
 
-- [ ] B-51: parts_cpus マイグレーション作成
-  - テスト: spec/models/parts_cpu_spec.rb
-  - 参照: docs/06_database-design.md
-
-- [ ] B-02: PartsCpu モデル実装
-  - バリデーション、アソシエーション
-
-- [ ] B-52: parts_gpus マイグレーション作成
-  - テスト: spec/models/parts_gpu_spec.rb
-
-- [ ] B-03: PartsGpu モデル実装
-
-- [ ] B-53: parts_memories マイグレーション作成
-  - テスト: spec/models/parts_memory_spec.rb
-
-- [ ] B-04: PartsMemory モデル実装
-
-- [ ] B-54: parts_storages マイグレーション作成
-  - テスト: spec/models/parts_storage_spec.rb
-
-- [ ] B-05: PartsStorage モデル実装
-
-- [ ] B-55: parts_os マイグレーション作成
-  - テスト: spec/models/parts_os_spec.rb
-
-- [ ] B-06: PartsOs モデル実装
-
-- [ ] B-56: parts_motherboards マイグレーション作成
-  - テスト: spec/models/parts_motherboard_spec.rb
-
-- [ ] B-07: PartsMotherboard モデル実装
-
-- [ ] B-57: parts_psus マイグレーション作成
-  - テスト: spec/models/parts_psu_spec.rb
-
-- [ ] B-08: PartsPsu モデル実装
-
-- [ ] B-58: parts_cases マイグレーション作成
-  - テスト: spec/models/parts_case_spec.rb
-
-- [ ] B-09: PartsCase モデル実装
+- [x] B-51: parts_cpus マイグレーション作成 (PR #8)
+- [x] B-02: PartsCpu モデル実装 (PR #8)
+- [x] B-52: parts_gpus マイグレーション作成 (PR #8)
+- [x] B-03: PartsGpu モデル実装 (PR #8)
+- [x] B-53: parts_memories マイグレーション作成 (PR #8)
+- [x] B-04: PartsMemory モデル実装 (PR #8)
+- [x] B-54: parts_storages マイグレーション作成 (PR #8)
+- [x] B-05: PartsStorage モデル実装 (PR #8)
+- [x] B-55: parts_os マイグレーション作成 (PR #8)
+- [x] B-06: PartsOs モデル実装 (PR #8)
+- [x] B-56: parts_motherboards マイグレーション作成 (PR #8)
+- [x] B-07: PartsMotherboard モデル実装 (PR #8)
+- [x] B-57: parts_psus マイグレーション作成 (PR #8)
+- [x] B-08: PartsPsu モデル実装 (PR #8)
+- [x] B-58: parts_cases マイグレーション作成 (PR #8)
+- [x] B-09: PartsCase モデル実装 (PR #8)
 
 ### 1.2 構成テーブル
 
-- [ ] B-59: pc_entrust_sets マイグレーション作成
-  - テスト: spec/models/pc_entrust_set_spec.rb
-
-- [ ] B-10: PcEntrustSet モデル実装
-  - アソシエーション: belongs_to各パーツ
-
-- [ ] B-60: pc_custom_sets マイグレーション作成
-  - テスト: spec/models/pc_custom_set_spec.rb
-
-- [ ] B-11: PcCustomSet モデル実装
-  - アソシエーション: belongs_to user, 各パーツ
+- [x] B-59: pc_entrust_sets マイグレーション作成 (PR #8)
+- [x] B-10: PcEntrustSet モデル実装 (PR #8)
+- [x] B-60: pc_custom_sets マイグレーション作成 (PR #8)
+- [x] B-11: PcCustomSet モデル実装 (PR #8)
 
 ---
 
@@ -278,9 +246,9 @@
 | フェーズ | タスク数 | 完了 | 進捗率 |
 |----------|---------|------|--------|
 | Phase 0: 環境整備 | 6 | 6 | 100% ✅ |
-| Phase 1: バックエンド基盤 | 20 | 0 | 0% |
+| Phase 1: バックエンド基盤 | 20 | 20 | 100% ✅ |
 | Phase 2: バックエンドAPI | 8 | 0 | 0% |
 | Phase 3: フロントエンド基盤 | 19 | 0 | 0% |
 | Phase 4: ユーザー向け画面 | 11 | 0 | 0% |
 | Phase 5: 管理者画面 | 8 | 0 | 0% |
-| **合計** | **72** | **6** | **8%** |
+| **合計** | **72** | **26** | **36%** |

--- a/docs/02_deliverables.md
+++ b/docs/02_deliverables.md
@@ -94,16 +94,16 @@
 | # | 成果物 | ファイルパス | 状態 |
 |---|--------|-------------|------|
 | B-01 | User モデル | `backend/app/models/user.rb` | 🔄 既存 |
-| B-02 | PartsCpu モデル | `backend/app/models/parts_cpu.rb` | ⬜ 未着手 |
-| B-03 | PartsGpu モデル | `backend/app/models/parts_gpu.rb` | ⬜ 未着手 |
-| B-04 | PartsMemory モデル | `backend/app/models/parts_memory.rb` | ⬜ 未着手 |
-| B-05 | PartsStorage モデル | `backend/app/models/parts_storage.rb` | ⬜ 未着手 |
-| B-06 | PartsOs モデル | `backend/app/models/parts_os.rb` | ⬜ 未着手 |
-| B-07 | PartsMotherboard モデル | `backend/app/models/parts_motherboard.rb` | ⬜ 未着手 |
-| B-08 | PartsPsu モデル | `backend/app/models/parts_psu.rb` | ⬜ 未着手 |
-| B-09 | PartsCase モデル | `backend/app/models/parts_case.rb` | ⬜ 未着手 |
-| B-10 | PcEntrustSet モデル | `backend/app/models/pc_entrust_set.rb` | ⬜ 未着手 |
-| B-11 | PcCustomSet モデル | `backend/app/models/pc_custom_set.rb` | ⬜ 未着手 |
+| B-02 | PartsCpu モデル | `backend/app/models/parts_cpu.rb` | ✅ 完了 |
+| B-03 | PartsGpu モデル | `backend/app/models/parts_gpu.rb` | ✅ 完了 |
+| B-04 | PartsMemory モデル | `backend/app/models/parts_memory.rb` | ✅ 完了 |
+| B-05 | PartsStorage モデル | `backend/app/models/parts_storage.rb` | ✅ 完了 |
+| B-06 | PartsOs モデル | `backend/app/models/parts_os.rb` | ✅ 完了 |
+| B-07 | PartsMotherboard モデル | `backend/app/models/parts_motherboard.rb` | ✅ 完了 |
+| B-08 | PartsPsu モデル | `backend/app/models/parts_psu.rb` | ✅ 完了 |
+| B-09 | PartsCase モデル | `backend/app/models/parts_case.rb` | ✅ 完了 |
+| B-10 | PcEntrustSet モデル | `backend/app/models/pc_entrust_set.rb` | ✅ 完了 |
+| B-11 | PcCustomSet モデル | `backend/app/models/pc_custom_set.rb` | ✅ 完了 |
 
 ### 3.2 コントローラー（API）
 
@@ -133,22 +133,22 @@
 | # | 成果物 | 説明 | 状態 |
 |---|--------|------|------|
 | B-50 | users テーブル | ユーザー情報 | 🔄 既存 |
-| B-51 | parts_cpus テーブル | CPU パーツ | ⬜ 未着手 |
-| B-52 | parts_gpus テーブル | GPU パーツ | ⬜ 未着手 |
-| B-53 | parts_memories テーブル | メモリ パーツ | ⬜ 未着手 |
-| B-54 | parts_storages テーブル | ストレージ パーツ | ⬜ 未着手 |
-| B-55 | parts_os テーブル | OS | ⬜ 未着手 |
-| B-56 | parts_motherboards テーブル | マザーボード | ⬜ 未着手 |
-| B-57 | parts_psus テーブル | 電源ユニット | ⬜ 未着手 |
-| B-58 | parts_cases テーブル | PCケース | ⬜ 未着手 |
-| B-59 | pc_entrust_sets テーブル | おまかせ構成 | ⬜ 未着手 |
-| B-60 | pc_custom_sets テーブル | カスタム構成 | ⬜ 未着手 |
+| B-51 | parts_cpus テーブル | CPU パーツ | ✅ 完了 |
+| B-52 | parts_gpus テーブル | GPU パーツ | ✅ 完了 |
+| B-53 | parts_memories テーブル | メモリ パーツ | ✅ 完了 |
+| B-54 | parts_storages テーブル | ストレージ パーツ | ✅ 完了 |
+| B-55 | parts_os テーブル | OS | ✅ 完了 |
+| B-56 | parts_motherboards テーブル | マザーボード | ✅ 完了 |
+| B-57 | parts_psus テーブル | 電源ユニット | ✅ 完了 |
+| B-58 | parts_cases テーブル | PCケース | ✅ 完了 |
+| B-59 | pc_entrust_sets テーブル | おまかせ構成 | ✅ 完了 |
+| B-60 | pc_custom_sets テーブル | カスタム構成 | ✅ 完了 |
 
 ### 3.6 テスト
 
 | # | 成果物 | ファイルパス | 状態 |
 |---|--------|-------------|------|
-| B-70 | モデルテスト | `backend/spec/models/` | ⬜ 未着手 |
+| B-70 | モデルテスト | `backend/spec/models/` | ✅ 完了 |
 | B-71 | コントローラーテスト | `backend/spec/requests/` | ⬜ 未着手 |
 | B-72 | サービステスト | `backend/spec/services/` | ⬜ 未着手 |
 
@@ -161,11 +161,11 @@
 | I-01 | Docker Compose | `docker-compose.yml` | ✅ 完了 |
 | I-02 | Backend Dockerfile | `backend/Dockerfile` | ✅ 完了 |
 | I-03 | Frontend Dockerfile | `frontend/Dockerfile` | ✅ 完了 |
-| I-04 | 環境変数サンプル（Backend） | `backend/.env.example` | ⬜ 未着手 |
-| I-05 | 環境変数サンプル（Frontend） | `frontend/.env.example` | ⬜ 未着手 |
-| I-06 | Next.js設定 | `frontend/next.config.ts` | ⬜ 未着手 |
-| I-07 | Tailwind設定 | `frontend/tailwind.config.ts` | ⬜ 未着手 |
-| I-08 | TypeScript設定 | `frontend/tsconfig.json` | ⬜ 未着手 |
+| I-04 | 環境変数サンプル（Backend） | `backend/.env.example` | ✅ 完了 |
+| I-05 | 環境変数サンプル（Frontend） | `frontend/.env.example` | ✅ 完了 |
+| I-06 | Next.js設定 | `frontend/next.config.ts` | ✅ 完了 |
+| I-07 | Tailwind設定 | `frontend/tailwind.config.ts` | ✅ 完了 |
+| I-08 | TypeScript設定 | `frontend/tsconfig.json` | ✅ 完了 |
 
 ---
 
@@ -175,9 +175,9 @@
 |----------|------|--------|------|
 | ドキュメント | 10 | 0 | 10 |
 | フロントエンド | 0 | 34 | 34 |
-| バックエンド | 2 | 25 | 27 |
-| インフラ | 3 | 5 | 8 |
-| **合計** | **15** | **64** | **79** |
+| バックエンド | 23 | 4 | 27 |
+| インフラ | 8 | 0 | 8 |
+| **合計** | **41** | **38** | **79** |
 
 ---
 


### PR DESCRIPTION
## Summary

- Plans.md: Phase 1 の全タスク（20件）を完了マーク
- 02_deliverables.md: モデル・マイグレーション・テストの状態を反映
- CLAUDE.md: タスク完了時の Plans.md 更新ルールを追加

## 背景

PR #8 で Phase 1 のバックエンド基盤実装が完了したが、進捗管理ファイルの更新が漏れていたため追加更新。

## 今後のルール

機能PRに進捗管理更新を含める運用に変更:
1. 機能実装完了時に Plans.md を `[x]` に更新
2. 同じPRに含めてマージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)